### PR TITLE
Fix: JWT Decoder is now capable to catch more categorized error 

### DIFF
--- a/src/core_apps/code_submit/process_data.py
+++ b/src/core_apps/code_submit/process_data.py
@@ -48,7 +48,7 @@ class ProcessData:
             A dict with user details from jwt claim, submission_uuid_id and testcases from Questions model.
         """
         # the payload from jwt
-        payload = jwt_decoder.decode_jwt(request=request)
+        payload, message = jwt_decoder.decode_jwt(request=request)
         if payload is not None:
             user_details = {
                 "user_id": payload.get("user_id"),
@@ -80,7 +80,6 @@ class ProcessData:
             message = "success"
             return data, message
         else:
-            message = "jwt-decode-error"
             logger.error(
                 f"\n[DATA PROCESS ERROR]: Data could not be processed. The error is: {message}"
             )

--- a/src/core_apps/code_submit/views.py
+++ b/src/core_apps/code_submit/views.py
@@ -38,11 +38,26 @@ class SubmitCode(APIView):
     """Submit Code to the code-manager service"""
 
     def process_error_response(self, message: str, problem_id: str = None) -> Response:
+        if message == "jwt-header-malformed":
+            return Response(
+                {
+                    "detail": "The JWT Authorization Header is missing or header is malformed."
+                },
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
         if message == "jwt-decode-error":
             return Response(
                 {"detail": "The JWT Token could not be verified"},
-                status=status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_401_UNAUTHORIZED,
             )
+
+        if message == "jwt-signature-expired":
+            return Response(
+                {"detail": "The JWT Signature is expired. Renew the JWT Token"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
         if message == "problem-id-error":
             return Response(
                 {"detail": f"The problem id {problem_id} is not valid."},

--- a/src/core_apps/code_submit/views.py
+++ b/src/core_apps/code_submit/views.py
@@ -51,10 +51,16 @@ class SubmitCode(APIView):
                 {"detail": "The JWT Token could not be verified"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
-
+            
         if message == "jwt-signature-expired":
             return Response(
                 {"detail": "The JWT Signature is expired. Renew the JWT Token"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+        
+        if message == "jwt-general-exception": 
+            return Response(
+                {"detail": "Some error occurred during decoding the JWT token."},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 

--- a/src/core_apps/common/jwt_decode.py
+++ b/src/core_apps/common/jwt_decode.py
@@ -56,7 +56,8 @@ class DecodeJWT:
         except (DecodeError, InvalidSignatureError, InvalidTokenError) as e:
             logger.error(f"\n[JWT ERROR]: JWT signature verification failed.\n[EXCEPTION]: {str(e)}")
             return None, "jwt-decode-error"
-
+        except Exception as e: 
+            return None, "jwt-general-exception"
 
 # instance to call
 jwt_decoder = DecodeJWT()


### PR DESCRIPTION
* fix the breaking of jwt decoder when the token was expired. 
* the decoder is now capable of handling more granular exceptions as well as general exception
* API response is generated as per specific JWT error occures. 