### PR TITLE
feat: 'CodeSubmitAPIRateLimitMiddleware' Rate Limit Middleware 

### DIFF
--- a/src/code_manager/settings/base.py
+++ b/src/code_manager/settings/base.py
@@ -76,6 +76,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "core_apps.code_submit.RateLimitMiddleware.CodeSubmitAPIRateLimitMiddleware", # middleware for rate limiting. (3 requsts per 60 sec)
 ]
 
 ROOT_URLCONF = "code_manager.urls"
@@ -184,4 +185,3 @@ REST_FRAMEWORK = {
 JWT_SIGNING_KEY = env("JWT_SIGNING_KEY")
 
 CORS_URLS_REGEX = r"^api/.*$"
-

--- a/src/code_manager/settings/dev.py
+++ b/src/code_manager/settings/dev.py
@@ -22,7 +22,23 @@ ALLOWED_HOSTS = ["127.0.0.1"]
 
 
 # Time to cache the code execution result in redis
-REDIS_CACHE_TIME_IN_SECONDS = int(env("REDIS_CACHE_TIME_IN_SECONDS"))
+REDIS_CACHE_HOST = env("REDIS_CACHE_HOST")
+
+REDIS_CACHE_RATELIMIT_DB_INDEX = int(env("REDIS_CACHE_RATELIMIT_DB_INDEX"))
+REDIS_CACHE_RESULT_DB_INDEX = int(env("REDIS_CACHE_RESULT_DB_INDEX"))
+
+# cache timeout for code exec result
+REDIS_CODE_EXEC_RESULT_CACHE_TIME_IN_SECONDS = int(
+    env("REDIS_CODE_EXEC_RESULT_CACHE_TIME_IN_SECONDS")
+)
+
+# cache timeout for code submit api rate limit
+REDIS_RATE_LIMIT_CACHE_TIME_IN_SECONDS = int(
+    env("REDIS_RATE_LIMIT_CACHE_TIME_IN_SECONDS")
+)
+
+# Code Submit API path. 
+CODE_SUBMIT_API_PATH = "/api/v1/code/submit/"
 
 # Config for MQ: Code Submission Publish
 CLOUD_AMQP_URL = env("CLOUD_AMQP_URL")

--- a/src/core_apps/code_result/mq_callback.py
+++ b/src/core_apps/code_result/mq_callback.py
@@ -4,7 +4,7 @@ import time
 import traceback
 
 
-import redis
+from redis import Redis
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 
@@ -18,10 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 try:
-    redis_client = redis.Redis(host="code-manager-redis", port=6379, db=0)
+    redis_client = Redis(
+        host=settings.REDIS_CACHE_HOST,
+        port=6379,
+        db=settings.REDIS_CACHE_RESULT_DB_INDEX,  # result cache index is 0, rate limit index is 1.
+    )
 except (ImproperlyConfigured, Exception) as e:
     logger.exception(
-        f"\n[Redis Import Error]: Error Occurred During Importing Reids\n[EXCEPTION]: {str(e)}"
+        f"\n[Redis Import Error]: Error Occurred During Importing Reids at MQ_CALLBACK\n[EXCEPTION]: {str(e)}"
     )
     raise ImproperlyConfigured("Redis is not available")
 
@@ -40,15 +44,15 @@ def callback(channel, method, properties, body):
         # body is in bytes. decodes to str then as dict
         result_data = json.loads(body.decode("utf-8"))
 
-
         # cached for immediate polling
         submission_id = result_data.get("submission_id")
         redis_client.set(submission_id, json.dumps(result_data))  #save as json 
         redis_client.expire(
-            name=submission_id, time=settings.REDIS_CACHE_TIME_IN_SECONDS
+            name=submission_id,
+            time=settings.REDIS_CODE_EXEC_RESULT_CACHE_TIME_IN_SECONDS,
         )  # currently 15 seconds
 
-        # saved in mongodb 
+        # saved in mongodb
         mongo_result_collection.insert_one(result_data)
 
         username = result_data["user_details"].get("username")

--- a/src/core_apps/code_submit/RateLimitMiddleware.py
+++ b/src/core_apps/code_submit/RateLimitMiddleware.py
@@ -1,0 +1,99 @@
+# pyhton
+import time
+import logging
+
+# django
+from django.http import JsonResponse
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from rest_framework.status import HTTP_429_TOO_MANY_REQUESTS
+
+# redis
+from redis import Redis
+
+logger = logging.getLogger(__name__)
+
+try:
+    redis_client = Redis(
+        host=settings.REDIS_CACHE_HOST,
+        port=6379,
+        db=settings.REDIS_CACHE_RATELIMIT_DB_INDEX,  # result cache index is 0, rate limit index is 1.
+    )
+except (ImproperlyConfigured, Exception) as e:
+    logger.exception(
+        f"\n[Redis Import Error]: Error Occurred During Importing Reids In RateLimit Middleware\n[EXCEPTION]: {str(e)}"
+    )
+    raise ImproperlyConfigured("Redis is not available")
+
+
+class CodeSubmitAPIRateLimitMiddleware:
+    """Rate Limit Middleware for '/api/v1/code/submit/' API.
+
+    Algorithm: TokenBucket Algorithm
+
+    Rules:
+        For each 20 seconds, a new token is added in the bucket.
+
+    """
+
+    def __init__(self, get_response) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def get_client_ip(self, request):
+        x_forwarded_for = request.META.get(
+            "X_FORWARDED_FOR"
+        )  # in case of proxy or load balancer
+        if x_forwarded_for:
+            ip_addr = x_forwarded_for.split(",")[0]
+        else:
+            ip_addr = request.META.get("REMOTE_ADDR")
+        return ip_addr
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        """The process_view method will be processed just before the actual view is called.
+        This is 'request phase' hook.
+        """
+        if request.path == settings.CODE_SUBMIT_API_PATH:
+            client_ip = self.get_client_ip(request=request)
+            rate_limit_key = f"api_rate_limit:{client_ip}"
+
+            max_tokens = 3
+            refill_rate = 1.0 / 20.0  # for each 20 seconds, 1 token is refilled.
+
+            bucket = redis_client.get(rate_limit_key)
+            curr_time = time.time()
+
+            if bucket is None:
+                bucket = {"tokens": max_tokens, "last_request_time": curr_time}
+            else:
+                bucket = eval(bucket)  # str to dict
+                elapsed_time = curr_time - bucket["last_request_time"]
+                new_tokens = elapsed_time * refill_rate
+                bucket["tokens"] = min(max_tokens, bucket["tokens"] + new_tokens)
+                bucket["last_request_time"] = curr_time
+
+            # checking token availability
+            if bucket["tokens"] >= 1:
+                bucket["tokens"] -= 1
+                redis_client.set(
+                    rate_limit_key,
+                    str(bucket),
+                    ex=settings.REDIS_RATE_LIMIT_CACHE_TIME_IN_SECONDS,
+                )
+            else:
+                wait_time_for_new_request = (1 - bucket["tokens"]) / refill_rate
+                return JsonResponse(
+                    {
+                        "message": "Rate limit exceed. Pleas wait before making another request.",
+                        "wait_time": f"{wait_time_for_new_request:.2f} seconds",
+                    },
+                    status=HTTP_429_TOO_MANY_REQUESTS,
+                )
+
+        # process the other middleware or view
+        return None

--- a/src/core_apps/code_submit/code_submission_producer.py
+++ b/src/core_apps/code_submit/code_submission_producer.py
@@ -81,19 +81,18 @@ class CodeSubmissionPublisherMQ(CloudAMQPHandler):
                     routing_key=settings.JAVA_CODE_SUBMISSION_ROUTING_KEY,
                     body=user_code_data,
                 )
-
+                
             logger.info(
-                f"\n[MQ SUCCESS]: The User Code Files of UseName: '{username}' of Language: '{lang}' Successfully Published to Submission MQ."
+                f"\n[MQ Code Submission Publish SUCCESS]: The User Code Files of UseName: '{username}' of Language: '{lang}' Successfully Published to Submission MQ."
             )
             message = "success"
             return True, message
         except Exception as e:
             logger.exception(
-                f"\n[MQ ERROR]: The User Code Files of UN: '{username}' of Language: '{lang}' Could not be published to Submission MQ.\n[MQ EXCEPTION]: {str(e)}"
+                f"\n[MQ Code Submission Publish ERROR]: The User Code Files of UN: '{username}' of Language: '{lang}' Could not be published to Submission MQ.\n[MQ EXCEPTION]: {str(e)}"
             )
             message = "error-publishing-to-code-submission-mq"
             return False, message
-
 
 # instance to call
 code_submission_publisher_mq = CodeSubmissionPublisherMQ()

--- a/src/dev.yml
+++ b/src/dev.yml
@@ -16,7 +16,7 @@ services:
       - ./.envs/.dev/.mongo
     depends_on: 
       - postgres 
-      - code-manager-redis
+      - codemanager-cache-redis
     command: /start  # start command to start the dev server and consume messages from mq 
     networks: 
       - algocode-code-manager-network
@@ -49,8 +49,10 @@ services:
     command: mongod --dbpath /data/db 
     networks:
       - algocode-code-manager-network
-      
-  code-manager-redis: 
+    
+  # Using a single redis instance for result cache and rate limiting as the server is limited on 1GB ram. 
+  # But if scale is needed, create another redis instance for rate limiting and update the Middleware. 
+  codemanager-cache-redis: 
     image: redis:7-alpine
     networks: 
       - algocode-code-manager-network


### PR DESCRIPTION
*  `CodeSubmitAPIRateLimitMiddleware` middleware to rate limit on the `/api/v1/code/submit/` API.

* This API is responsible to submit the user code in the code manager which will be published to the code submission queue and consumed by the RCE Engine to execute the code

* As the server has only 1GB,  rate limiting the API to mitigate overwhelming the server

* Some other code refactoring has also been performed. 